### PR TITLE
Add appveyor.yml and badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <br/>
 
 ![Unidays NuGet Badge](https://img.shields.io/nuget/1.2/unidays-dotnet.svg)
+[![Build status](https://ci.appveyor.com/api/projects/status/xjfdbra2ea85qd27?svg=true)](https://ci.appveyor.com/project/UNiDAYS/unidays-dotnet)
 
 # UNiDAYS .NET Library
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+image: Visual Studio 2017
+version: 1.0.{build}-{branch}
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.cs'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+configuration: Release
+branches:
+  only:
+    - master
+skip_tags: true
+max_jobs: 1
+init:
+  - git config --global core.autocrlf true
+clone_depth: 1
+artifacts:
+  - path: '*.nupkg'
+#------ tests configuration ------#
+test_script:
+  - cmd: dotnet restore ./src/Unidays.Tests/Unidays.Tests.csproj --verbosity m
+  - cmd: cd ./src/Unidays.Tests/
+  - cmd: dotnet test
+#---- deployment configuration ----#
+deploy:
+  provider: NuGet
+  api_key:
+    secure: {NUGET_KEY}
+  on:
+    branch:
+      - master


### PR DESCRIPTION
### Requirements

Add Appveyor yml so that we can use appveyor as our build tool

### Description of the Change
Add Appveyor yml

### Verification Process

Push to appveyor to see if the tests pass and the package gets deployed to nuget successfully
