### PR TITLE
Change query builder to include null keys

### DIFF
--- a/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsPresent.cs
+++ b/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsPresent.cs
@@ -39,6 +39,16 @@ namespace Unidays.Client.Tests.TrackingHelperTests
             [InlineData("PartnerId", "a partner")]
             [InlineData("TransactionId", "the transaction")]
             [InlineData("Currency", "GBP")]
+            [InlineData("OrderTotal", "")]
+            [InlineData("ItemsUNiDAYSDiscount", "")]
+            [InlineData("Code", "")]
+            [InlineData("ItemsTax", "")]
+            [InlineData("ShippingGross", "")]
+            [InlineData("ShippingDiscount", "")]
+            [InlineData("ItemsGross", "")]
+            [InlineData("ItemsOtherDiscount", "")]
+            [InlineData("UNiDAYSDiscountPercentage", "")]
+            [InlineData("NewCustomer", "")]
             public void TheParameterShouldBeCorrect(string parameter, string result)
             {
                 var parameters = HttpUtility.ParseQueryString(this.url.Query);

--- a/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSet.cs
+++ b/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSet.cs
@@ -62,7 +62,7 @@ namespace Unidays.Client.Tests.TrackingHelperTests
             [InlineData("ItemsOtherDiscount", "10.00")]
             [InlineData("UNiDAYSDiscountPercentage", "10.00")]
             [InlineData("NewCustomer", "True")]
-            [InlineData("Signature", "pXFZGuMoAFwUcyurd+wtC7rauRD2ekFBudoP+mP4B+2vfepvS4ndwGcGo8ghxEoA0gc/vFG/q/DuIOGuff650w==")]
+            [InlineData("Signature", "fqkvDz2i/L6o/KydDcpb6PAgX50CR9Alq4DsYKEdP9pCXRo51VuAhcTlDHvZ4Vx27OAa0TkxfVQYsjs5z6bOwA==")]
             public void TheParameterShouldBeCorrect(string parameter, string result)
             {
                 var parameters = HttpUtility.ParseQueryString(this.url.Query);

--- a/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsPresent.cs
+++ b/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsPresent.cs
@@ -42,7 +42,17 @@ namespace Unidays.Client.Tests.TrackingHelperTests
             [InlineData("PartnerId", "a partner")]
             [InlineData("TransactionId", "the transaction")]
             [InlineData("Currency", "GBP")]
-            [InlineData("Signature", "3h2gRkUHrvzvdHysCaIZwaSWiNCU4Bx4n3wYjlOsf1WpHqK5gqQSZa1B7JQVsPkriXD0jcf06wtGF//sCfmKnA==")]
+            [InlineData("OrderTotal", "")]
+            [InlineData("ItemsUNiDAYSDiscount", "")]
+            [InlineData("Code", "")]
+            [InlineData("ItemsTax", "")]
+            [InlineData("ShippingGross", "")]
+            [InlineData("ShippingDiscount", "")]
+            [InlineData("ItemsGross", "")]
+            [InlineData("ItemsOtherDiscount", "")]
+            [InlineData("UNiDAYSDiscountPercentage", "")]
+            [InlineData("NewCustomer", "")]
+            [InlineData("Signature", "CmHoChVU1M8h+clza7oCRKATUDWUMZiwOOBHZf93qT3yx1vrP40D9/LPdL7HjaX3nnfQ5dlXDghdmxLTQk7W9A==")]
             public void TheParameterShouldBeCorrect(string parameter, string result)
             {
                 var parameters = HttpUtility.ParseQueryString(this.url.Query);

--- a/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSet.cs
+++ b/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSet.cs
@@ -62,8 +62,8 @@ namespace Unidays.Client.Tests.TrackingHelperTests
             [InlineData("ItemsOtherDiscount", "10.00")]
             [InlineData("UNiDAYSDiscountPercentage", "10.00")]
             [InlineData("NewCustomer", "True")]
-            [InlineData("Signature", "pXFZGuMoAFwUcyurd+wtC7rauRD2ekFBudoP+mP4B+2vfepvS4ndwGcGo8ghxEoA0gc/vFG/q/DuIOGuff650w==")]
             [InlineData("Test", "True")]
+            [InlineData("Signature", "fqkvDz2i/L6o/KydDcpb6PAgX50CR9Alq4DsYKEdP9pCXRo51VuAhcTlDHvZ4Vx27OAa0TkxfVQYsjs5z6bOwA==")]
             public void TheParameterShouldBeCorrect(string parameter, string result)
             {
                 var parameters = HttpUtility.ParseQueryString(this.url.Query);

--- a/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSet.cs
+++ b/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSet.cs
@@ -61,7 +61,7 @@ namespace Unidays.Client.Tests.TrackingHelperTests
             [InlineData("ItemsOtherDiscount", "10.00")]
             [InlineData("UNiDAYSDiscountPercentage", "10.00")]
             [InlineData("NewCustomer", "True")]
-            [InlineData("Signature", "ubCLOIdBw1LL9KN6B0zFTU8K5+G2WSm6S5hXmWYV9Kv/w5LQAJaUq9hhkt1A4q5BssurypqH4IH/kjmeD5TlwQ==")]
+            [InlineData("Signature", "9KETSe8bP8KKTQ13bGNsuc8b3RzwmTUrLhq/PynXLDCtxeICXfP7LSKosuowD+6DSTdPdd1IoWx5Gc0MdwPx0A==")]
             public void TheParameterShouldBeCorrect(string parameter, string result)
             {
                 var parameters = HttpUtility.ParseQueryString(this.url.Query);

--- a/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSet.cs
+++ b/src/Unidays.Client.Tests/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSet.cs
@@ -61,7 +61,7 @@ namespace Unidays.Client.Tests.TrackingHelperTests
             [InlineData("ItemsOtherDiscount", "10.00")]
             [InlineData("UNiDAYSDiscountPercentage", "10.00")]
             [InlineData("NewCustomer", "True")]
-            [InlineData("Signature", "ubCLOIdBw1LL9KN6B0zFTU8K5+G2WSm6S5hXmWYV9Kv/w5LQAJaUq9hhkt1A4q5BssurypqH4IH/kjmeD5TlwQ==")]
+            [InlineData("Signature", "9KETSe8bP8KKTQ13bGNsuc8b3RzwmTUrLhq/PynXLDCtxeICXfP7LSKosuowD+6DSTdPdd1IoWx5Gc0MdwPx0A==")]
             [InlineData("Test", "True")]
             public void TheParameterShouldBeCorrect(string parameter, string result)
             {

--- a/src/Unidays.Client/Internal/StringBuilderExtensions.cs
+++ b/src/Unidays.Client/Internal/StringBuilderExtensions.cs
@@ -16,39 +16,50 @@ namespace Unidays.Client.Internal
                 .Append(HttpUtility.UrlEncode(directTrackingDetails.TransactionId))
                 .Append("&Currency=")
                 .Append(HttpUtility.UrlEncode(directTrackingDetails.Currency));
-
+            
+            builder.Append("&MemberId=");
             if (!string.IsNullOrEmpty(directTrackingDetails.MemberId))
-                builder.Append("&MemberId=").AppendFormat(HttpUtility.UrlEncode(directTrackingDetails.MemberId));
-
+               builder.AppendFormat(HttpUtility.UrlEncode(directTrackingDetails.MemberId));
+            
+            builder.Append("&Code=");
             if (!string.IsNullOrEmpty(directTrackingDetails.Code))
-                builder.Append("&Code=").Append(HttpUtility.UrlEncode(directTrackingDetails.Code));
-
+                builder.AppendFormat(HttpUtility.UrlEncode(directTrackingDetails.Code));
+           
+            builder.Append("&OrderTotal=");
             if (directTrackingDetails.OrderTotal.HasValue)
-                builder.Append("&OrderTotal=").AppendFormat("{0:0.00}", directTrackingDetails.OrderTotal.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.OrderTotal.Value);
 
+            builder.Append("&ItemsUNiDAYSDiscount=");
             if (directTrackingDetails.ItemsUNiDAYSDiscount.HasValue)
-                builder.Append("&ItemsUNiDAYSDiscount=").AppendFormat("{0:0.00}", directTrackingDetails.ItemsUNiDAYSDiscount.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.ItemsUNiDAYSDiscount.Value);
 
+            builder.Append("&ItemsTax=");
             if (directTrackingDetails.ItemsTax.HasValue)
-                builder.Append("&ItemsTax=").AppendFormat("{0:0.00}", directTrackingDetails.ItemsTax.Value);
-
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.ItemsTax.Value);
+           
+            builder.Append("&ShippingGross=");
             if (directTrackingDetails.ShippingGross.HasValue)
-                builder.Append("&ShippingGross=").AppendFormat("{0:0.00}", directTrackingDetails.ShippingGross.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.ShippingGross.Value);
 
+            builder.Append("&ShippingDiscount=");
             if (directTrackingDetails.ShippingDiscount.HasValue)
-                builder.Append("&ShippingDiscount=").AppendFormat("{0:0.00}", directTrackingDetails.ShippingDiscount.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.ShippingDiscount.Value);
 
+            builder.Append("&ItemsGross=");
             if (directTrackingDetails.ItemsGross.HasValue)
-                builder.Append("&ItemsGross=").AppendFormat("{0:0.00}", directTrackingDetails.ItemsGross.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.ItemsGross.Value);
 
+            builder.Append("&ItemsOtherDiscount=");
             if (directTrackingDetails.ItemsOtherDiscount.HasValue)
-                builder.Append("&ItemsOtherDiscount=").AppendFormat("{0:0.00}", directTrackingDetails.ItemsOtherDiscount.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.ItemsOtherDiscount.Value);
 
+            builder.Append("&UNiDAYSDiscountPercentage=");
             if (directTrackingDetails.UNiDAYSDiscountPercentage.HasValue)
-                builder.Append("&UNiDAYSDiscountPercentage=").AppendFormat("{0:0.00}", directTrackingDetails.UNiDAYSDiscountPercentage.Value);
+                builder.AppendFormat("{0:0.00}", directTrackingDetails.UNiDAYSDiscountPercentage.Value);
 
+            builder.Append("&NewCustomer=");
             if (directTrackingDetails.NewCustomer.HasValue)
-                builder.Append("&NewCustomer=").AppendFormat("{0}", directTrackingDetails.NewCustomer);
+                builder.AppendFormat("{0}", directTrackingDetails.NewCustomer);
 
             return builder;
         }


### PR DESCRIPTION

### Requirements

Change the .NET implementation to include keys in the query string even when values aren't provided for them to match the node library implementation
