### PR TITLE
Fix Codeless Date Parameter Decoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ script:
 - cd src
 - dotnet restore
 - dotnet test Unidays.Client.Tests
-- dotnet pack Unidays.Client -c Release /property:PackageVersion=1.1.$TRAVIS_BUILD_NUMBER
+- dotnet pack Unidays.Client -c Release /property:PackageVersion=1.2.$TRAVIS_BUILD_NUMBER
 - cd -
 deploy:
   skip_cleanup: true
   provider: script
-  script: bash deploy.sh 1.1.$TRAVIS_BUILD_NUMBER $NUGET_API_KEY
+  script: bash deploy.sh 1.2.$TRAVIS_BUILD_NUMBER $NUGET_API_KEY
   on:
     branch: master
 notifications:

--- a/src/Unidays.Client.Tests/CodelessUrlVerifierTests/WhenVerifyingAValidHash.cs
+++ b/src/Unidays.Client.Tests/CodelessUrlVerifierTests/WhenVerifyingAValidHash.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -23,7 +23,7 @@ namespace Unidays.Client.Tests.CodelessUrlVerifierTests
 
             var verified = _codelessUrlVerifier.VerifyUrlParams(ud_s, ud_t, ud_h);
 
-            verified.Should().Be(new DateTime(Convert.ToInt64(ud_t), DateTimeKind.Utc));
+            verified.Should().Be(new DateTime(2015, 01, 01, 00, 00, 00, DateTimeKind.Utc));
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Unidays.Client.Tests.CodelessUrlVerifierTests
             var uri = new Uri("https://test.com?ud_s=eesNa1l1bUWKHsWfOLemXQ%3D%3D&ud_t=1420070400&ud_h=qaOotWTdl1GjooDmgagETc4ov8FPo4U7rE5RDp0Gfnmo4UVe5JDQhQYDgi1CXNwYa8xSXE4B0QmM96kqf4DLsw%3D%3D");
             var verified = _codelessUrlVerifier.VerifyUrl(uri);
 
-            verified.Should().Be(new DateTime(Convert.ToInt64(1420070400), DateTimeKind.Utc));
+            verified.Should().Be(new DateTime(2015, 01, 01, 00, 00, 00, DateTimeKind.Utc));
         }
     }
 }

--- a/src/Unidays.Client.sln
+++ b/src/Unidays.Client.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29209.62
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unidays", "Unidays.Client\Unidays.Client.csproj", "{AA92318B-4574-4402-81F9-B13C7E56EAE5}"
 EndProject

--- a/src/Unidays.Client/CodelessUrlVerifier.cs
+++ b/src/Unidays.Client/CodelessUrlVerifier.cs
@@ -28,14 +28,14 @@ namespace Unidays.Client
             }
         }
 
-        private string StringToHmacSHA512(StringBuilder queryString)
+        private string StringToHmacSHA512(string queryString)
         {
             using (var hmac = new HMACSHA512())
             {
                 hmac.Key = _key;
 
                 hmac.Initialize();
-                var buffer = Encoding.ASCII.GetBytes(queryString.ToString());
+                var buffer = Encoding.ASCII.GetBytes(queryString);
                 var signatureBytes = hmac.ComputeHash(buffer);
                 var signature = Convert.ToBase64String(signatureBytes);
                 return signature;
@@ -52,9 +52,7 @@ namespace Unidays.Client
         /// <exception cref="SystemException">Throws exception if the url is not able to be verified</exception>
         public DateTime? VerifyUrlParams(string ud_s, string ud_t, string ud_h)
         {
-            var queryString = new StringBuilder();
-            queryString.Append("?ud_s=").AppendFormat(HttpUtility.UrlEncode(ud_s) ?? "")
-                        .Append("&ud_t=").AppendFormat(HttpUtility.UrlEncode(ud_t) ?? "");
+            var queryString = $"?ud_s={HttpUtility.UrlEncode(ud_s)}&ud_t={HttpUtility.UrlEncode(ud_t)}";
 
             try
             {

--- a/src/Unidays.Client/CodelessUrlVerifier.cs
+++ b/src/Unidays.Client/CodelessUrlVerifier.cs
@@ -11,6 +11,7 @@ namespace Unidays.Client
     public sealed class CodelessUrlVerifier
     {
         private readonly byte[] _key;
+        private static readonly DateTime Epoch = new DateTime(1970, 01, 01, 00, 00, 00, DateTimeKind.Utc);
 
         public CodelessUrlVerifier(string key)
         {
@@ -62,7 +63,7 @@ namespace Unidays.Client
                 if (ud_h != hash) return null;
 
                 var timeSinceEpoch = Convert.ToInt64(ud_t);
-                return new DateTime(timeSinceEpoch, DateTimeKind.Utc);
+                return Epoch.AddSeconds(timeSinceEpoch);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Description of the Change

- In implementing this code I noticed incorrect values (dates very close to year 0) being returned for what should be much more recent timestamps. This change removes implementation from tests and fixes the bug. The implementation assumed that the constructor of `DateTime` accepts seconds since 1970-01-01T00:00:00Z, instead the `DateTime(long)` constructor accepts a value such that it is "the number of 100-nanosecond intervals that have elapsed since January 1, 0001 at 00:00:00.000 in the Gregorian calendar."

- Upgraded the sln to VS2019.

### Benefits

The correct date will be returned corresponding to the date the URL was constructed and signed.

### Possible Drawbacks

N/A

### Verification Process

Corrected the unit test covering this functionality and verified it passed once the implementation had been corrected.

### Applicable Issues

N/A